### PR TITLE
fix(ui): read compression model from correct API path

### DIFF
--- a/package/frontend/src/components/ConfigManager.jsx
+++ b/package/frontend/src/components/ConfigManager.jsx
@@ -53,7 +53,7 @@ const ConfigManager = ({ adminToken }) => {
         EMOTION_BASE_URL: response.data.emotion?.base_url || '',
         MAX_CONCURRENT_USERS: response.data.system.max_concurrent_users?.toString() || '',
         HISTORY_COMPRESSION_THRESHOLD: response.data.system.history_compression_threshold?.toString() || '',
-        COMPRESSION_MODEL: response.data.system.compression_model || '',
+        COMPRESSION_MODEL: response.data.compression?.model || '',
         COMPRESSION_API_KEY: response.data.compression?.api_key || '',
         COMPRESSION_BASE_URL: response.data.compression?.base_url || '',
         DEFAULT_USAGE_LIMIT: response.data.system.default_usage_limit?.toString() || '',


### PR DESCRIPTION
## Summary
- Fixed bug where compression model config was not loading in admin panel
- Frontend was reading from `response.data.system.compression_model` (doesn't exist)
- Changed to `response.data.compression?.model` to match backend API response

## Root Cause
The backend `/api/admin/config` returns compression settings under `compression.model`, but the frontend was looking for it under `system.compression_model`.

## Test plan
- [x] Go to admin panel → System Config
- [x] Verify compression model field now correctly displays the configured value
- [x] Verify saving compression model works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)