### PR TITLE
feat(ci): auto-build executable on push to main branch

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -2,6 +2,8 @@ name: Build Executable
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Add `branches: [main]` trigger to `.github/workflows/build-exe.yml` so the workflow runs automatically on every push to `main`, not only on version tags.

## Motivation
Currently the exe build only triggers on `v*` tags. Adding the `branches` filter enables a CI-first release workflow where pushing any commit to `main` automatically triggers an exe build, without requiring a manual tag step.

## Changes
```diff
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
```
