### PR TITLE
fix: concurrency bug fixes + session isolation + CI auto-build

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: "缺陷报告 / Bug Report"
+description: "提交 Bug 帮助我们改进产品"
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🐛 提交前请检查
+
+        - ✅ 我已搜索过已有 Issue，确认没有重复
+        - ✅ 我已尝试阅读文档或 FAQ，确认不是操作问题
+        - ✅ 我已尽量提供完整的信息帮助定位问题
+
+        ---
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "问题描述"
+      description: "请用一两句话清晰描述你遇到的问题（什么功能、发生了什么异常）"
+      placeholder: "例如：点击「生成论文」按钮后，页面一直显示加载中，没有任何响应"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "复现步骤"
+      description: "请按 1. 2. 3. 的格式，一步一步描述如何复现该问题"
+      placeholder: |
+        1. 打开程序，进入「论文生成」页面
+        2. 输入论文标题为「XXX」
+        3. 点击「生成」按钮
+        4. 页面卡住，Console 报错：XXXX
+      value: "1.\n2.\n3."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "预期结果"
+      description: "你认为正常情况下应该发生什么？"
+      placeholder: "应正常生成论文并显示结果页面"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "实际结果"
+      description: "实际上发生了什么？"
+      placeholder: "按钮点击后无响应，页面白屏"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "日志 / 截图"
+      description: "如果有程序日志、浏览器 Console 报错或截图，请贴在这里（非常重要）"
+      placeholder: "拖拽图片到此处上传，或粘贴日志文本。日志文件通常位于 exe 同目录下的 logs/ 文件夹中"
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: "程序版本"
+      description: "exe 文件名中或程序界面上的版本号"
+      placeholder: "例如：v1.0.0 或 构建日期 2026-05-19"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: "操作系统"
+      description: "你正在使用的操作系统"
+      options:
+        - Windows 10
+        - Windows 11
+        - Windows 其他
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: "其他补充"
+      description: "任何可能有帮助的额外信息（是否使用了代理、网络环境、特殊配置等）"
+      placeholder: "无"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 使用文档
+    url: https://github.com/Liber1917/BypassAIGC#readme
+    about: 提交 Issue 前，请先阅读使用文档，确认不是操作问题
+  - name: 💬 讨论区 / Q&A
+    url: https://github.com/Liber1917/BypassAIGC/discussions
+    about: 如有使用疑问或建议，欢迎在 Discussion 中讨论

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: "功能建议 / Feature Request"
+description: "提交新的功能需求或改进建议"
+title: "[建议] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 💡 提交前请检查
+
+        - ✅ 我已搜索过已有 Issue，确认没有重复建议
+        - ✅ 我的建议与 AI 学术写作助手的产品定位相符
+
+        ---
+
+  - type: textarea
+    id: background
+    attributes:
+      label: "背景 / 场景"
+      description: "说明你在什么场景下遇到了这个需求，当前有什么痛点？"
+      placeholder: "我在撰写毕业论文时，需要频繁调整参考文献格式，目前需要手动修改，效率很低……"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "需求描述"
+      description: "请从用户视角描述你希望程序新增或改进什么功能"
+      placeholder: "希望新增一个「一键格式化参考文献」功能，用户上传 BibTeX 文件后自动转换为指定格式……"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "验收标准"
+      description: "什么样的表现才算是满足了这个需求？请尽量用 checklist 列出"
+      placeholder: |
+        - [ ] 支持 GB/T 7714 格式输出
+        - [ ] 支持 APA 7th 格式输出
+        - [ ] 支持批量导入 BibTeX 文件
+        - [ ] 导出后可直接复制到 Word
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "优先级"
+      description: "你觉得这个功能有多重要？"
+      options:
+        - P0 - 影响核心使用，急需
+        - P1 - 重要，希望近期实现
+        - P2 - 不错的功能，有时间可以做
+        - P3 - 锦上添花
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: "参考示例"
+      description: "如果有其他同类产品实现了类似功能，请提供截图或链接"
+      placeholder: "例如：Notion AI 的写作辅助功能……"
+    validations:
+      required: false

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -2,6 +2,8 @@ name: Build Executable
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:

--- a/package/backend/app/database.py
+++ b/package/backend/app/database.py
@@ -5,7 +5,10 @@ from app.config import settings
 
 engine = create_engine(
     settings.DATABASE_URL,
-    connect_args={"check_same_thread": False} if "sqlite" in settings.DATABASE_URL else {}
+    connect_args={"check_same_thread": False} if "sqlite" in settings.DATABASE_URL else {},
+    pool_size=20,
+    max_overflow=30,
+    pool_recycle=3600,
 )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/package/backend/app/main.py
+++ b/package/backend/app/main.py
@@ -71,7 +71,7 @@ if settings.ADMIN_PASSWORD == "admin123":
 app = FastAPI(
     title="AI 论文润色增强系统",
     description="高质量论文润色与原创性学术表达增强",
-    version="1.0.0"
+    version="2.6.5"
 )
 
 # 添加 Gzip 压缩中间件以减少响应体积

--- a/package/backend/app/routes/optimization.py
+++ b/package/backend/app/routes/optimization.py
@@ -20,6 +20,8 @@ from sse_starlette.sse import EventSourceResponse
 
 router = APIRouter(prefix="/optimization", tags=["optimization"])
 
+running_tasks: dict[str, asyncio.Task] = {}
+
 
 def get_current_user(authorization: Optional[str] = Header(None), db: Session = Depends(get_db)) -> User:
     if not authorization or not authorization.startswith("Bearer "):
@@ -39,8 +41,10 @@ def get_current_user(authorization: Optional[str] = Header(None), db: Session = 
     return user
 
 
-async def run_optimization(session_id: int):
+async def run_optimization(session_id: int, session_key: str):
     """后台运行优化任务（独立 DB 会话）"""
+    task = asyncio.current_task()
+    running_tasks[session_key] = task
     db = SessionLocal()
     try:
         session_obj = db.query(OptimizationSession).filter(
@@ -52,8 +56,11 @@ async def run_optimization(session_id: int):
         
         service = OptimizationService(db, session_obj)
         await service.start_optimization()
+    except asyncio.CancelledError:
+        pass  # 任务被取消，正常退出
     finally:
         db.close()
+        running_tasks.pop(session_key, None)
 
 
 @router.post("/start", response_model=SessionResponse)
@@ -110,7 +117,7 @@ async def start_optimization(
     db.commit()
     db.refresh(session)
     
-    background_tasks.add_task(run_optimization, session.id)
+    background_tasks.add_task(run_optimization, session.id, session_id)
     
     return session
 
@@ -387,7 +394,7 @@ async def delete_session(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
-    """删除会话"""
+    """删除会话，同时取消后台任务并释放并发槽位"""
     user = current_user
     
     session = db.query(OptimizationSession).filter(
@@ -397,6 +404,14 @@ async def delete_session(
     
     if not session:
         raise HTTPException(status_code=404, detail="会话不存在")
+    
+    # 取消后台运行中的 asyncio Task
+    task = running_tasks.pop(session_id, None)
+    if task and not task.done():
+        task.cancel()
+    
+    # 释放并发槽位
+    await concurrency_manager.release(session_id)
     
     db.delete(session)
     db.commit()
@@ -431,7 +446,7 @@ async def retry_session(
     session.error_message = f"[重试中] 上次失败原因: {old_error}"
     db.commit()
 
-    background_tasks.add_task(run_optimization, session.id)
+    background_tasks.add_task(run_optimization, session.id, session_id)
 
     return {"message": "已重新排队处理未完成段落"}
 
@@ -442,7 +457,7 @@ async def stop_session(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
-    """停止正在进行中的会话"""
+    """停止正在进行中的会话，取消后台任务并释放并发槽位"""
     user = current_user
 
     session = db.query(OptimizationSession).filter(
@@ -455,6 +470,14 @@ async def stop_session(
 
     if session.status not in ["queued", "processing"]:
         raise HTTPException(status_code=400, detail="只能停止排队中或处理中的会话")
+
+    # 取消后台运行中的 asyncio Task
+    task = running_tasks.pop(session_id, None)
+    if task and not task.done():
+        task.cancel()
+
+    # 释放并发槽位
+    await concurrency_manager.release(session_id)
 
     # 更新状态为 stopped
     session.status = "stopped"

--- a/package/backend/app/services/concurrency.py
+++ b/package/backend/app/services/concurrency.py
@@ -128,6 +128,9 @@ class ConcurrencyManager:
                 break  # 此用户已达上限，跳过
             self.queue.pop(0)
             self.active_sessions[next_session] = datetime.utcnow()
+            if user_id is not None:
+                self._session_user[next_session] = user_id
+                self.active_per_user[user_id] = self.active_per_user.get(user_id, 0) + 1
 
 
 # 全局并发管理器实例

--- a/package/backend/app/services/optimization_service.py
+++ b/package/backend/app/services/optimization_service.py
@@ -78,15 +78,7 @@ class OptimizationService:
     async def start_optimization(self):
         """开始优化流程"""
         try:
-            # 初始化AI服务
-            self._init_ai_services()
-
-            # 重置错误状态
-            self.session_obj.error_message = None
-            self.session_obj.failed_segment_index = None
-            self.db.commit()
-            
-            # 获取并发权限
+            # 先获取并发权限（避免未授权就分配 DB 连接和 AI 客户端）
             acquired = await concurrency_manager.acquire(self.session_obj.session_id, user_id=self.session_obj.user_id)
             if not acquired:
                 self.session_obj.status = "queued"
@@ -96,6 +88,9 @@ class OptimizationService:
                 acquired = await concurrency_manager.acquire(self.session_obj.session_id, user_id=self.session_obj.user_id)
                 if not acquired:
                     raise Exception("等待并发权限超时")
+            
+            # 再初始化 AI 服务
+            self._init_ai_services()
             
             # 更新状态为处理中
             self.session_obj.status = "processing"

--- a/package/backend/app/word_formatter/services/job_manager.py
+++ b/package/backend/app/word_formatter/services/job_manager.py
@@ -93,6 +93,7 @@ class JobManager:
     ):
         self._jobs: Dict[str, Job] = {}
         self._job_locks: Dict[str, asyncio.Lock] = {}
+        self._running_tasks: Dict[str, asyncio.Task] = {}  # 跟踪运行中的任务，用于取消
         self._semaphore = asyncio.Semaphore(max_concurrent_jobs)
         self._job_retention = timedelta(hours=job_retention_hours)
         self._cleanup_task: Optional[asyncio.Task] = None
@@ -169,6 +170,10 @@ class JobManager:
         print(f"[WORD-FORMATTER] Job ID: {job_id[:8]}... 类型: {job.job_type.value}", flush=True)
 
         async with self._semaphore:
+            # 注册当前 task，用于 delete_job 时取消
+            current_task = asyncio.current_task()
+            self._running_tasks[job_id] = current_task
+
             async with self._job_locks[job_id]:
                 job.status = JobStatus.RUNNING
                 job.updated_at = datetime.now()
@@ -181,6 +186,15 @@ class JobManager:
                     else:
                         raise ValueError(f"Unknown job type: {job.job_type}")
 
+                except asyncio.CancelledError:
+                    # 任务被取消，释放 semaphore 槽位
+                    job.status = JobStatus.CANCELLED
+                    job.updated_at = datetime.now()
+                    job.error = "任务被用户取消"
+                    print(f"[WORD-FORMATTER] ⚠️ 任务被取消 job_id={job_id[:8]}...", flush=True)
+                    # 重新抛出 CancelledError，让 asyncio 处理
+                    raise
+
                 except Exception as e:
                     import traceback
                     job.status = JobStatus.FAILED
@@ -189,6 +203,10 @@ class JobManager:
                     print(f"[WORD-FORMATTER] 异常类型: {type(e).__name__}", flush=True)
                     print(f"[WORD-FORMATTER] 异常信息: {e}", flush=True)
                     print(f"[WORD-FORMATTER] 堆栈跟踪:\n{traceback.format_exc()}", flush=True)
+
+                finally:
+                    # 确保清理运行任务记录
+                    self._running_tasks.pop(job_id, None)
 
                 job.updated_at = datetime.now()
                 print(f"[WORD-FORMATTER] ========== 任务执行结束 ==========\n", flush=True)
@@ -288,11 +306,19 @@ class JobManager:
         return False
 
     def delete_job(self, job_id: str) -> bool:
-        """Delete a job and its data."""
+        """Delete a job and its data. For RUNNING jobs, also cancels the asyncio task to release semaphore."""
         if job_id in self._jobs:
+            job = self._jobs[job_id]
+            if job.status == JobStatus.RUNNING:
+                # 取消正在运行的任务，释放 semaphore 槽位
+                task = self._running_tasks.get(job_id)
+                if task and not task.done():
+                    task.cancel()
+                    print(f"[WORD-FORMATTER] 🛑 取消运行中的任务 job_id={job_id[:8]}...", flush=True)
             del self._jobs[job_id]
             if job_id in self._job_locks:
                 del self._job_locks[job_id]
+            self._running_tasks.pop(job_id, None)
             return True
         return False
 
@@ -411,14 +437,19 @@ class JobManager:
         # 停止清理循环
         self.stop_cleanup_loop()
 
-        # 取消所有运行中的任务
-        for job_id, job in list(self._jobs.items()):
-            if job.status == JobStatus.RUNNING:
-                job.status = JobStatus.CANCELLED
-                job.error = "服务关闭，任务被取消"
+        # 取消所有运行中的任务，释放 semaphore 槽位
+        for job_id, task in list(self._running_tasks.items()):
+            if not task.done():
+                task.cancel()
+                print(f"[WORD-FORMATTER] 🛑 关闭时取消任务 job_id={job_id[:8]}...", flush=True)
+
+        # 等待任务取消完成（可选，防止立即清理）
+        if self._running_tasks:
+            await asyncio.sleep(0.1)  # 给取消的任务一点时间处理 CancelledError
 
         # 清空任务字典
         self._jobs.clear()
+        self._running_tasks.clear()
 
     def get_stats(self) -> Dict[str, int]:
         """Get job statistics."""

--- a/package/backend/tests/test_job_deletion_bug.py
+++ b/package/backend/tests/test_job_deletion_bug.py
@@ -1,0 +1,195 @@
+"""
+Bug reproduction test: 删除 RUNNING 状态任务时，semaphore 槽位不释放。
+
+Root cause: DELETE /jobs/{job_id} 直接调用 job_manager.delete_job(job_id)
+            而 delete_job() 只从 _jobs 字典中删除记录，
+            不中断底层 asyncio task，导致 semaphore 槽位直到任务自然结束才释放。
+
+Fix: 在 JobManager 中维护 _running_tasks(job_id -> asyncio.Task) 映射，
+     delete_job() 时对 RUNNING 任务调用 task.cancel()。
+"""
+import asyncio
+import time
+import pytest
+
+from app.word_formatter.services.job_manager import (
+    JobManager,
+    JobStatus,
+    JobType,
+)
+
+
+class TestDeleteRunningJobSemaphoreBug:
+    """Reproduce: deleting a RUNNING job does not release the semaphore slot."""
+
+    @pytest.fixture
+    def job_manager(self):
+        """Create a job manager with max 2 concurrent jobs for fast testing."""
+        jm = JobManager(max_concurrent_jobs=2, job_retention_hours=1)
+        yield jm
+        jm._jobs.clear()
+        jm._job_locks.clear()
+
+    @pytest.mark.asyncio
+    async def test_delete_running_job_keeps_semaphore_blocked(self, job_manager):
+        """
+        BUG REPRODUCTION TEST.
+        Step 1: Fill semaphore with 2 blocking jobs (use asyncio.Event to control)
+        Step 2: Delete one RUNNING job via delete_job()
+        Step 3: Submit job #3 -> should acquire semaphore immediately
+        BUG: job #3 is BLOCKED because deleted job's asyncio task still holds semaphore slot
+        """
+        job1_started = asyncio.Event()
+        job1_can_finish = asyncio.Event()
+
+        async def blocking_format_job(job):
+            """Job that blocks until job1_can_finish is set."""
+            job1_started.set()
+            await job1_can_finish.wait()
+
+        job_manager._run_format_job = blocking_format_job
+
+        job1 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text1")
+        job2 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text2")
+
+        task1 = asyncio.create_task(job_manager.run_job(job1.job_id))
+        task2 = asyncio.create_task(job_manager.run_job(job2.job_id))
+        await job1_started.wait()
+        await asyncio.sleep(0.05)
+
+        stats = job_manager.get_stats()
+        assert stats["running"] == 2
+        print(f"[TEST] Both jobs running, semaphore filled. Stats: {stats}")
+
+        # Step 2: Delete job1 (what the API DELETE endpoint does)
+        deleted = job_manager.delete_job(job1.job_id)
+        assert deleted is True
+        assert job_manager.get_job(job1.job_id) is None
+        print("[TEST] Job1 deleted from dict, but task1 still holds semaphore")
+
+        # Step 3: Try to submit job #3
+        job3_blocking = asyncio.Event()
+
+        async def blocking_job3(job):
+            job3_blocking.set()
+            await asyncio.sleep(30)
+
+        job_manager._run_format_job = blocking_job3
+        job3 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text3")
+        task3 = asyncio.create_task(job_manager.run_job(job3.job_id))
+
+        await asyncio.sleep(0.2)
+        acquired = job3_blocking.is_set()
+        print(f"[TEST] Job3 acquired semaphore within 0.2s: {acquired}")
+
+        # BUG: if not acquired -> job3 is blocked, semaphore starvation confirmed
+        assert acquired, (
+            "BUG REPRODUCED: Deleted RUNNING job still holds the semaphore slot. "
+            "Job3 is BLOCKED waiting for a slot that should have been freed by delete_job(). "
+            "Fix: delete_job() must call task.cancel() on the running asyncio task."
+        )
+
+        task1.cancel()
+        task2.cancel()
+        task3.cancel()
+        try:
+            await asyncio.gather(task1, task2, task3, return_exceptions=True)
+        except (asyncio.CancelledError, RuntimeError):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_delete_pending_job_is_immediate(self, job_manager):
+        """
+        Deleting a PENDING (not yet started) job has no semaphore impact.
+        """
+        job1_started = asyncio.Event()
+        job1_can_finish = asyncio.Event()
+
+        async def blocking_job2(job):
+            job1_started.set()
+            await job1_can_finish.wait()
+
+        job_manager._run_format_job = blocking_job2
+        job1 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text1")
+        job2 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text2")
+        task2 = asyncio.create_task(job_manager.run_job(job2.job_id))
+        await job1_started.wait()
+        assert job_manager.get_stats()["pending"] == 1
+
+        deleted = job_manager.delete_job(job1.job_id)
+        assert deleted is True
+        assert job_manager.get_stats()["pending"] == 0
+
+        job3_started = asyncio.Event()
+
+        async def blocking_job3(job):
+            job3_started.set()
+            await asyncio.sleep(30)
+
+        job_manager._run_format_job = blocking_job3
+        job3 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text3")
+        task3 = asyncio.create_task(job_manager.run_job(job3.job_id))
+        await asyncio.sleep(0.3)
+
+        assert job3_started.is_set()
+        print("[TEST] PENDING job deletion: no semaphore starvation")
+
+        task2.cancel()
+        task3.cancel()
+        try:
+            await asyncio.gather(task2, task3, return_exceptions=True)
+        except (asyncio.CancelledError, RuntimeError):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_cancel_then_delete_still_holds_slot(self, job_manager):
+        """
+        cancel_job() only sets CANCELLED status, does NOT cancel the asyncio task.
+        This is graceful cancellation - correct by design.
+        """
+        job_started = asyncio.Event()
+        job_can_finish = asyncio.Event()
+
+        async def blocking_job(job):
+            job_started.set()
+            await job_can_finish.wait()
+
+        job_manager._run_format_job = blocking_job
+        job1 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text1")
+        task1 = asyncio.create_task(job_manager.run_job(job1.job_id))
+        await job_started.wait()
+
+        cancelled = await job_manager.cancel_job(job1.job_id)
+        assert cancelled is True
+        assert job_manager.get_job(job1.job_id).status == JobStatus.CANCELLED
+
+        job_manager.delete_job(job1.job_id)
+
+        job3_started = asyncio.Event()
+
+        async def blocking_job3(job):
+            job3_started.set()
+            await asyncio.sleep(30)
+
+        job_manager._run_format_job = blocking_job3
+        job3 = job_manager.create_job(JobType.FORMAT, user_id="u1", input_text="text3")
+        task3 = asyncio.create_task(job_manager.run_job(job3.job_id))
+        await asyncio.sleep(0.3)
+
+        # cancel_job() only sets CANCELLED status in dict, does NOT cancel the asyncio task.
+        # But in this test, we call task1.cancel() which DOES release semaphore
+        # (task.cancel() raises CancelledError at next await, which releases semaphore).
+        # So the semaphore IS freed - this is expected Python asyncio behavior.
+        assert job3_started.is_set()
+        print("[TEST] cancel+delete: task.cancel() releases semaphore (asyncio behavior)")
+
+        task1.cancel()
+        task3.cancel()
+        try:
+            await asyncio.gather(task1, task3, return_exceptions=True)
+        except (asyncio.CancelledError, RuntimeError):
+            pass
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/package/frontend/package.json
+++ b/package/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-polish-frontend",
-  "version": "1.0.0",
+  "version": "2.6.5",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package/frontend/src/App.jsx
+++ b/package/frontend/src/App.jsx
@@ -12,7 +12,7 @@ import FormatCheckerPage from './pages/FormatCheckerPage';
 import './index.css';
 
 const ProtectedRoute = ({ children }) => {
-  const token = localStorage.getItem('authToken');
+  const token = sessionStorage.getItem('authToken');
   
   if (!token) {
     return <Navigate to="/" replace />;

--- a/package/frontend/src/api/index.js
+++ b/package/frontend/src/api/index.js
@@ -15,7 +15,7 @@ const api = axios.create({
 // 请求拦截器
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('authToken');
+    const token = sessionStorage.getItem('authToken');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -33,8 +33,8 @@ api.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('authToken');
-      localStorage.removeItem('username');
+      sessionStorage.removeItem('authToken');
+      sessionStorage.removeItem('username');
       window.location.href = '/';
     }
     return Promise.reject(error);
@@ -126,7 +126,7 @@ export const optimizationAPI = {
       timeout: 15000, // 15秒超时
     }),
   getStreamUrl: (sessionId) => {
-    const token = localStorage.getItem('authToken');
+    const token = sessionStorage.getItem('authToken');
     const baseUrl = api.defaults.baseURL || '/api';
     return `${baseUrl}/optimization/sessions/${sessionId}/stream?token=${token}`;
   },
@@ -193,14 +193,14 @@ export const wordFormatterAPI = {
 
   // Download
   getDownloadUrl: (jobId) => {
-    const token = localStorage.getItem('authToken');
+    const token = sessionStorage.getItem('authToken');
     const baseUrl = api.defaults.baseURL || '/api';
     return `${baseUrl}/word-formatter/jobs/${jobId}/download?token=${token}`;
   },
 
   // SSE stream URL
   getStreamUrl: (jobId) => {
-    const token = localStorage.getItem('authToken');
+    const token = sessionStorage.getItem('authToken');
     const baseUrl = api.defaults.baseURL || '/api';
     return `${baseUrl}/word-formatter/jobs/${jobId}/stream?token=${token}`;
   },
@@ -231,7 +231,7 @@ export const wordFormatterAPI = {
 
   // Preprocess stream URL
   getPreprocessStreamUrl: (jobId) => {
-    const token = localStorage.getItem('authToken');
+    const token = sessionStorage.getItem('authToken');
     const baseUrl = api.defaults.baseURL || '/api';
     return `${baseUrl}/word-formatter/preprocess/${jobId}/stream?token=${token}`;
   },

--- a/package/frontend/src/pages/WelcomePage.jsx
+++ b/package/frontend/src/pages/WelcomePage.jsx
@@ -24,9 +24,9 @@ const WelcomePage = () => {
     try {
       const response = await authAPI.login(username, password);
       const { access_token, display_name } = response.data;
-      localStorage.setItem('authToken', access_token);
-      localStorage.setItem('username', username);
-      if (display_name) localStorage.setItem('displayName', display_name);
+      sessionStorage.setItem('authToken', access_token);
+      sessionStorage.setItem('username', username);
+      if (display_name) sessionStorage.setItem('displayName', display_name);
       toast.success('登录成功');
       navigate('/workspace');
     } catch (error) {

--- a/package/frontend/src/pages/WordFormatterPage.jsx
+++ b/package/frontend/src/pages/WordFormatterPage.jsx
@@ -311,8 +311,8 @@ const WordFormatterPage = () => {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('username');
+    sessionStorage.removeItem('authToken');
+    sessionStorage.removeItem('username');
     navigate('/');
   };
 

--- a/package/frontend/src/pages/WorkspacePage.jsx
+++ b/package/frontend/src/pages/WorkspacePage.jsx
@@ -228,8 +228,8 @@ const WorkspacePage = () => {
   }, [text, processingMode, isSubmitting, loadSessions]);
 
   const handleLogout = useCallback(() => {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('username');
+    sessionStorage.removeItem('authToken');
+    sessionStorage.removeItem('username');
     navigate('/');
   }, [navigate]);
 

--- a/package/main.py
+++ b/package/main.py
@@ -83,7 +83,7 @@ if settings.ADMIN_PASSWORD == "admin123":
 app = FastAPI(
     title="AI 论文润色增强系统",
     description="高质量论文润色与原创性学术表达增强",
-    version="1.0.0"
+    version="2.6.5"
 )
 
 # 添加 Gzip 压缩中间件以减少响应体积


### PR DESCRIPTION
## Changes (1 commit, 18 files)

- **word_formatter**: cancel asyncio Task on DELETE to release semaphore slot
- **ci**: push-to-main auto-build trigger
- **optimization**: _activate_waiting_locked now updates per-user counter
- **optimization**: acquire() moved before _init_ai_services()
- **routes**: DELETE/STOP now cancel tasks + release concurrency slots
- **database**: pool_size=20 for concurrent background tasks
- **frontend**: localStorage to sessionStorage for tab-level session isolation
- **version**: bump to 2.6.5
- **tests**: add test_job_deletion_bug.py (3 regression tests)
- **issues**: add Chinese issue templates