### PR TITLE
fix: harden OOXML archive parsing

### DIFF
--- a/package/backend/app/word_formatter/utils/ooxml.py
+++ b/package/backend/app/word_formatter/utils/ooxml.py
@@ -11,6 +11,40 @@ from typing import Dict
 from lxml import etree
 
 
+MAX_ARCHIVE_ENTRIES = 2048
+MAX_ARCHIVE_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+MAX_ARCHIVE_ENTRY_BYTES = 50 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 1000
+
+
+def _read_archive(archive: zipfile.ZipFile) -> Dict[str, bytes]:
+    infos = archive.infolist()
+    if len(infos) > MAX_ARCHIVE_ENTRIES:
+        raise ValueError("DOCX archive contains too many entries")
+
+    names = [info.filename for info in infos]
+    if len(names) != len(set(names)):
+        raise ValueError("DOCX archive contains duplicate entries")
+
+    total_size = 0
+    for info in infos:
+        if info.flag_bits & 0x1:
+            raise ValueError("Encrypted DOCX archives are not supported")
+        if info.file_size > MAX_ARCHIVE_ENTRY_BYTES:
+            raise ValueError("DOCX archive entry is too large")
+        total_size += info.file_size
+        if total_size > MAX_ARCHIVE_UNCOMPRESSED_BYTES:
+            raise ValueError("DOCX archive expands beyond the safety limit")
+        if (
+            info.file_size > 1024 * 1024
+            and info.compress_size > 0
+            and info.file_size / info.compress_size > MAX_COMPRESSION_RATIO
+        ):
+            raise ValueError("DOCX archive has a suspicious compression ratio")
+
+    return {info.filename: archive.read(info) for info in infos if not info.is_dir()}
+
+
 @dataclass
 class DocxPackage:
     files: Dict[str, bytes]
@@ -18,13 +52,13 @@ class DocxPackage:
     @classmethod
     def from_path(cls, path: str) -> "DocxPackage":
         with zipfile.ZipFile(path, "r") as z:
-            files = {name: z.read(name) for name in z.namelist()}
+            files = _read_archive(z)
         return cls(files=files)
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "DocxPackage":
         with zipfile.ZipFile(io.BytesIO(data), "r") as z:
-            files = {name: z.read(name) for name in z.namelist()}
+            files = _read_archive(z)
         return cls(files=files)
 
     def to_bytes(self) -> bytes:
@@ -42,7 +76,8 @@ class DocxPackage:
     def read_xml(self, name: str) -> etree._Element:
         if name not in self.files:
             raise KeyError(f"missing file in docx: {name}")
-        return etree.fromstring(self.files[name])
+        parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True, huge_tree=False)
+        return etree.fromstring(self.files[name], parser=parser)
 
     def write_xml(self, name: str, root: etree._Element) -> None:
         self.files[name] = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone="yes")

--- a/package/backend/tests/test_ooxml_security.py
+++ b/package/backend/tests/test_ooxml_security.py
@@ -1,0 +1,34 @@
+import io
+import unittest
+import zipfile
+
+from app.word_formatter.utils.ooxml import DocxPackage
+
+
+class OoxmlSecurityTests(unittest.TestCase):
+    def test_suspicious_compression_ratio_is_rejected(self):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("word/document.xml", b"A" * (4 * 1024 * 1024))
+
+        with self.assertRaises(ValueError):
+            DocxPackage.from_bytes(buffer.getvalue())
+
+    def test_external_entities_are_not_resolved(self):
+        package = DocxPackage(
+            files={
+                "word/document.xml": (
+                    b'<!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+                    b"<root>&xxe;</root>"
+                )
+            }
+        )
+
+        root = package.read_xml("word/document.xml")
+
+        self.assertIsNone(root.text)
+        self.assertEqual(len(root), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bound DOCX ZIP entry count, per-entry size, total expanded size, and compression ratio before reading payloads
- reject encrypted and duplicate archive entries
- parse OOXML with external entities, DTD loading, network access, and huge-tree mode disabled
- add focused regression tests for ZIP bomb and XXE payloads

## Why
Uploaded DOCX files are untrusted ZIP/XML input. The previous implementation eagerly read every archive entry and parsed XML with default parser settings, allowing excessive memory use and unsafe entity processing.

## Validation
- `python -m unittest discover -s package/backend/tests -p test_ooxml_security.py -v`
- 2 tests passed

This PR intentionally avoids branding, UI, deployment, and unrelated refactors.