### PR TITLE
docs: 更新 README 中失效的 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ git push origin v1.0.0
 
 Creative Commons (CC BY-NC-SA 4.0)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=chi111i/BypassAIGC&type=Date)](https://star-history.com/#chi111i/BypassAIGC)
+[![Star History Chart](https://star-history.dera.page/svg?repos=chi111i/BypassAIGC&type=Date)](https://star-history.dera.page/#chi111i/BypassAIGC&type=Date)
 
 
 


### PR DESCRIPTION
README 底部的 Star History 图表目前无法正常展示，因为原图表服务受到 GitHub 数据接口限制的影响。

本 PR 将图表链接更新为可正常工作的服务地址，图表即可恢复显示，方便读者查看项目星标趋势。